### PR TITLE
Mention dns in docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,23 +3,31 @@ version: "3"
 services:
   firefox:
     image: selenium/standalone-firefox-debug:3.14.0-curium
+    
     ports:
       - "4444:4444"
       - "5900:5900"
+    
     volumes:
       - "/dev/shm:/dev/shm"
+    
     networks:
       - selenium
+  
   whatsapp:
-     build: .
-     environment:
+    dns:
+      - 8.8.8.8
+    build: .
+    
+    environment:
        - SELENIUM=http://firefox:4444/wd/hub
-     volumes:
+    
+    volumes:
        - ".:/app"
        -  ./cached-packages:/usr/local/lib/f_whatsapp/python/site-packages/
-     networks:
+    networks:
        - selenium
-     depends_on:
+    depends_on:
        - firefox
 
 volumes:


### PR DESCRIPTION
Without this it was causing `pymongo.errors.ConfigurationError: None of DNS query names exist: `